### PR TITLE
🏷️ Use "import type" when possible

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,5 +27,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run type-check
     - run: npm run build --if-present
     - run: npm test -- --testTimeout 5000

--- a/author.ts
+++ b/author.ts
@@ -1,5 +1,5 @@
 import type {OnEvent, OnEventObject, RelayPool} from "./relay-pool";
-import {Filter, Kind} from "nostr-tools";
+import {type Filter, Kind} from "nostr-tools";
 import type {EventObject} from "./event";
 
 export class Author {

--- a/collect.ts
+++ b/collect.ts
@@ -1,5 +1,5 @@
-import {Event} from "nostr-tools";
-import {OnEvent} from "./on-event-filters";
+import type {Event} from "nostr-tools";
+import type {OnEvent} from "./on-event-filters";
 
 const binarySearch = function (a: Event[], target: Event) {
   var l = 0,

--- a/event-cache-test.ts
+++ b/event-cache-test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import {Kind, Event} from "nostr-tools";
+import {Kind, type Event} from "nostr-tools";
 import {EventCache} from "./event-cache";
 
 describe("EventCache", () => {

--- a/event-cache.ts
+++ b/event-cache.ts
@@ -1,4 +1,4 @@
-import {Filter, Kind, Event} from "nostr-tools";
+import {type Filter, Kind, type Event} from "nostr-tools";
 
 export class EventCache {
   eventsById: Map<string, Event> = new Map();

--- a/event-demultiplexer-test.ts
+++ b/event-demultiplexer-test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import {Filter, matchFilter, Event, UnsignedEvent} from "nostr-tools";
+import {type Filter, matchFilter, type Event, type UnsignedEvent} from "nostr-tools";
 import {EventDemultiplexer} from "./event-demultiplexer";
 
 let eventFrom = (event: UnsignedEvent & {id: string}) => {

--- a/event-demultiplexer.ts
+++ b/event-demultiplexer.ts
@@ -1,4 +1,4 @@
-import {Filter, matchFilter, Event} from "nostr-tools";
+import {type Filter, matchFilter, type Event} from "nostr-tools";
 import type {OnEvent} from "./on-event-filters";
 
 export class EventDemultiplexer {

--- a/event-demultiplexer.ts
+++ b/event-demultiplexer.ts
@@ -1,5 +1,5 @@
 import {Filter, matchFilter, Event} from "nostr-tools";
-import {OnEvent} from "./on-event-filters";
+import type {OnEvent} from "./on-event-filters";
 
 export class EventDemultiplexer {
   filterAndOnEventByEvent: Map<string, [Filter, OnEvent][]> = new Map();

--- a/event-persister.ts
+++ b/event-persister.ts
@@ -36,3 +36,6 @@
 //     }
 //   }
 // }
+
+// Needed for isolatedModules to not complain
+export const __unused = true;

--- a/event.ts
+++ b/event.ts
@@ -1,6 +1,6 @@
-import {Kind, Event} from "nostr-tools";
+import type {Kind, Event} from "nostr-tools";
 import {Author} from "./author";
-import {RelayPool} from "./relay-pool";
+import type {RelayPool} from "./relay-pool";
 
 import type {OnEvent} from "./on-event-filters";
 export class EventObject implements Event {

--- a/group-filters-by-relay.ts
+++ b/group-filters-by-relay.ts
@@ -1,4 +1,4 @@
-import {Filter, Event} from "nostr-tools";
+import type {Filter, Event} from "nostr-tools";
 import {mergeSimilarAndRemoveEmptyFilters} from "./merge-similar-filters";
 import {
   doNotEmitDuplicateEvents,
@@ -6,8 +6,8 @@ import {
   matchOnEventFilters,
   type OnEvent,
 } from "./on-event-filters";
-import {EventCache} from "./event-cache";
-import {FilterToSubscribe} from "./relay-pool";
+import type {EventCache} from "./event-cache";
+import type {FilterToSubscribe} from "./relay-pool";
 import {CallbackReplayer} from "./callback-replayer";
 
 const unique = (arr: string[]) => [...new Set(arr)];

--- a/in-memory-relay-server.ts
+++ b/in-memory-relay-server.ts
@@ -1,4 +1,4 @@
-import {Event, Filter, matchFilters} from "nostr-tools";
+import {type Event, type Filter, matchFilters} from "nostr-tools";
 import {WebSocket, WebSocketServer} from "isomorphic-ws";
 
 const _ = WebSocket; // Importing WebSocket is needed for WebSocketServer to work

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -1,4 +1,4 @@
-import {Event} from "nostr-tools";
+import type {Event} from "nostr-tools";
 
 export class MetadataCache {
   data: Map<string, Event>;

--- a/newest-event-cache.ts
+++ b/newest-event-cache.ts
@@ -1,5 +1,5 @@
-import {Event, Filter} from "nostr-tools";
-import {RelayPool} from "./relay-pool";
+import type {Event, Filter} from "nostr-tools";
+import type {RelayPool} from "./relay-pool";
 
 export class NewestEventCache {
   data: Map<string, Event>;

--- a/on-event-filters.ts
+++ b/on-event-filters.ts
@@ -1,5 +1,5 @@
-import {Filter, Kind, matchFilter, Event} from "nostr-tools";
-import {EventObject} from "./event";
+import {type Filter, Kind, matchFilter, type Event} from "nostr-tools";
+import type {EventObject} from "./event";
 export type OnEventArgs = [
   event: Event,
   afterEose: boolean,

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "build": "node build.js",
     "pretest": "node build.js",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
-    "publish": "npm i && npm run build && npm run test -- --testTimeout 5000 && npm publish"
+    "publish": "npm i && npm run build && npm run test -- --testTimeout 5000 && npm publish",
+    "type-check": "tsc"
   }
 }

--- a/relay-pool-worker.ts
+++ b/relay-pool-worker.ts
@@ -1,5 +1,5 @@
 import type {Event} from "nostr-tools";
-import {OnEose, OnEvent, SubscriptionOptions} from "./relay-pool";
+import type {OnEose, OnEvent, SubscriptionOptions} from "./relay-pool";
 
 export class RelayPoolWorker {
   // eslint-disable-next-line no-undef

--- a/relay-pool.test.ts
+++ b/relay-pool.test.ts
@@ -5,7 +5,7 @@ import {
   generatePrivateKey,
   getEventHash,
   getPublicKey,
-  Event,
+  type Event,
 } from "nostr-tools";
 import {RelayPool} from "./relay-pool";
 import {InMemoryRelayServer} from "./in-memory-relay-server";

--- a/relay-pool.ts
+++ b/relay-pool.ts
@@ -1,14 +1,14 @@
-import {Filter, Event} from "nostr-tools";
+import type {Filter, Event} from "nostr-tools";
 import {mergeSimilarAndRemoveEmptyFilters} from "./merge-similar-filters";
 import {type Relay, relayInit, Sub} from "./relay";
-import {OnEventObject, type OnEvent} from "./on-event-filters";
+import type {OnEventObject, OnEvent} from "./on-event-filters";
 import {EventCache} from "./event-cache";
 import {EventObject} from "./event";
 import {
   batchFiltersByRelay,
   groupFiltersByRelayAndEmitCacheHits,
 } from "./group-filters-by-relay";
-import {CallbackReplayer} from "./callback-replayer";
+import type {CallbackReplayer} from "./callback-replayer";
 import {NewestEventCache} from "./newest-event-cache";
 
 const unique = (arr: string[]) => [...new Set(arr)];

--- a/relay-pool.ts
+++ b/relay-pool.ts
@@ -1,6 +1,6 @@
 import type {Filter, Event} from "nostr-tools";
 import {mergeSimilarAndRemoveEmptyFilters} from "./merge-similar-filters";
-import {type Relay, relayInit, Sub} from "./relay";
+import {type Relay, relayInit, type Sub} from "./relay";
 import type {OnEventObject, OnEvent} from "./on-event-filters";
 import {EventCache} from "./event-cache";
 import {EventObject} from "./event";

--- a/relay-pool.worker.ts
+++ b/relay-pool.worker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 // worker.ts
-import {RelayPool, SubscriptionOptions} from "./relay-pool";
+import {RelayPool, type SubscriptionOptions} from "./relay-pool";
 import type {Event} from "nostr-tools";
 
 let relayPool: RelayPool;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "importsNotUsedAsValues": "error",
+    "preserveValueImports": true,
+    "isolatedModules": true,
     "outDir": "dist",
     "rootDir": ".",
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
+    "importsNotUsedAsValues": "error",
     "outDir": "dist",
     "rootDir": ".",
   }


### PR DESCRIPTION
Ensure that `import type` is used when possible

## Motivation

See https://github.com/microsoft/TypeScript/issues/41883

If an application with stricter TS settings includes this module, they will get TS error, no way to ignore it. For example, with the default SvelteKit template, there will be errors.

Alternative is publishing `.d.ts` files instead of `.ts` files for the `types` field in `package.json`.