### PR TITLE
Simplify metadata-cache.ts

### DIFF
--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -1,20 +1,14 @@
 import type {Event} from "nostr-tools";
 
 export class MetadataCache {
-  data: Map<string, Event>;
   promises: Map<string, Promise<Event>>;
   servers: string[];
   constructor(servers?: string[]) {
-    this.data = new Map();
     this.promises = new Map();
     this.servers = servers || ["https://us.rbr.bio", "https://eu.rbr.bio"];
   }
 
   async get(pubkey: string): Promise<Event> {
-    let value = this.data.get(pubkey);
-    if (value) {
-      return Promise.resolve(value);
-    }
     const promise = this.promises.get(pubkey);
     if (promise) {
       return promise;
@@ -23,11 +17,7 @@ export class MetadataCache {
     for (let server of this.servers) {
       rs.push(fetchMetadata(server, pubkey));
     }
-    const r = firstGoodPromise(rs);
-    r.then((x) => {
-      this.data.set(pubkey, x);
-      this.promises.delete(pubkey);
-    });
+    const r = Promise.any(rs);
     this.promises.set(pubkey, r);
     return r;
   }
@@ -39,20 +29,6 @@ async function fetchJSON(url: string) {
     .catch((e) => {
       throw new Error("error fetching " + url + " " + e);
     });
-}
-
-function firstGoodPromise<T>(promises: Promise<T>[]): Promise<T> {
-  return new Promise((resolve, reject) => {
-    let rejects: any[] = [];
-    promises.forEach((p) => {
-      p.then(resolve).catch((rej) => {
-        rejects.push(rej);
-        if (rejects.length === promises.length) {
-          reject(rejects);
-        }
-      });
-    });
-  });
 }
 
 function fetchMetadata(server: string, pubkey: string) {


### PR DESCRIPTION
Much of the code in this module is unnecessary:

- Promises can be reused. A separate `data` map is not needed, and is no different from just reusing the promise.
- [`Promise.any()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any) can replace the `firstGoodPromise()` function.