### PR TITLE
Worker: fix order of onerror params

### DIFF
--- a/relay-pool.worker.ts
+++ b/relay-pool.worker.ts
@@ -20,7 +20,7 @@ self.onmessage = (event: MessageEvent<MessageData>) => {
       relayPool = new RelayPool(data.relays, data.options);
 
       // Set event listeners
-      relayPool.onerror((err, relayUrl) => {
+      relayPool.onerror((relayUrl, err) => {
         postMessage({type: "error", err, relayUrl});
       });
 


### PR DESCRIPTION
They are in the wrong order, causing output that looks like this:

```
Feb 02 20:55:33 gleasonator deno[903762]: Unhandled message from worker: { type: "error", err: "wss://relay.current.fyi/", relayUrl: undefined }
Feb 02 20:55:33 gleasonator deno[903762]: Unhandled message from worker: { type: "error", err: "wss://relay.current.fyi/", relayUrl: {} }
Feb 02 20:55:33 gleasonator deno[903762]: Unhandled message from worker: { type: "error", err: "wss://relay.current.fyi/", relayUrl: undefined }
```